### PR TITLE
中文翻譯新增

### DIFF
--- a/ch2.md
+++ b/ch2.md
@@ -183,9 +183,13 @@ This command interpreter then executes the commands in the script, starting at t
 
 Each of the above script header lines calls a different command interpreter, be it /bin/sh, the default shell (bash in a Linux system) or otherwise. [4] 
 
-以上每行腳本標頭代表呼叫不同的指令直譯器(command interpreter)，可以透過 /bin/sh (Linux 系統的 bash)或其他程式執行它[4]。
+>`以上每行腳本標頭代表呼叫不同的指令直譯器(command interpreter)，可以透過 /bin/sh (Linux 系統的 bash)或其他程式執行它[4]。`
 
-Using #!/bin/sh, the default Bourne shell in most commercial variants of UNIX, makes the script portable to non-Linux machines, though you sacrifice Bash-specific features. The script will, however, conform to the POSIX [5] sh standard.
+Using #!/bin/sh, the default Bourne shell in most commercial variants of UNIX, makes the script portable to non-Linux machines, though you sacrifice Bash-specific features. 
+
+>`#!/bin/sh 是最商業化 Unix 預設的 Bourne shell，使用它可以使腳本移植到非 Linux 系統，雖然必須犧牲部分 Bash 功能。`
+
+The script will, however, conform to the POSIX [5] sh standard.
 
 Note that the path given at the "sha-bang" must be correct, otherwise an error message -- usually "Command not found." -- will be the only result of running the script. [6]
 


### PR DESCRIPTION
Using #!/bin/sh, the default Bourne shell in most commercial variants of UNIX, makes the script portable to non-Linux machines, though you sacrifice Bash-specific features. 

> `#!/bin/sh 是最商業化 Unix 預設的 Bourne shell，使用它可以使腳本移植到非 Linux 系統，雖然必須犧牲部分 Bash 功能。`
